### PR TITLE
Add tdx CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,36 @@ npm i --save-dev github:pihart/typedoc
 
 ## Usage
 
+### Library
+
 ```js
 const typedoc = require("typedoc-wrapper");
 
 typedoc("./src/index.ts");
 ```
+
+Signature:
+
+```ts
+(
+  mainFile: string, // filepath, relative or absolute
+  {
+    customTagsJSONFile = DEFAULTS.CUSTOM_TAGS_JSON_FILE,
+    themeDir = DEFAULTS.THEME_DIR,
+    hideGenerator = true,
+  }: {
+    customTagsJSONFile: string // path to JSON file defining custom tags,
+    themeDir: string // path to theme directory,
+    hideGenerator: boolean // whether to hide the message indicating generation by typedoc
+  } = {}
+) => Promise<unknown>;
+```
+
+### CLI
+
+```shell
+tpx path-to-file
+```
+
+Does not yet support options like the library command does;
+see <https://github.com/pihart/typedoc/pull/4>;

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const run = require("../src");
+const { argv, stdout } = process;
+const [, , filePath] = argv;
+
+if (filePath === undefined) {
+  stdout.write("Usage: tdx path-to-file");
+  process.exitCode = 2;
+} else {
+  run(filePath);
+  process.exitCode = 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-wrapper",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.2.0",
   "description": "Wrapper for typedoc and typedoc-plugin-custom-tags",
   "main": "src/index.js",
+  "bin": {
+    "tdx": "./bin/index.js"
+  },
   "dependencies": {
     "typedoc": "^0.20.19",
     "typedoc-plugin-custom-tags": "github:pihart/typedoc-plugin-custom-tags#pihart-dist-v1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-wrapper",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Wrapper for typedoc and typedoc-plugin-custom-tags",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Invoke as
```shell
tdx <path-to-file>
```

Currently does not support config options to be passed to `run()` because of a lack of need and to keep the dependency tree small

Resolves https://github.com/pihart/typedoc/issues/3